### PR TITLE
alteracoes na linha 642 da unit SimpleRTTI

### DIFF
--- a/SimpleRTTI.pas
+++ b/SimpleRTTI.pas
@@ -638,6 +638,9 @@ begin
           
         if Attribute is AutoInc then
           vIgnore := True;
+
+        if Attribute is Ignore then
+          vIgnore := True;
       end;
       if not vIgnore then
         aFields := aFields + vCampo + ', ';


### PR DESCRIPTION
não adicionar no INSERT campos passados como ignore dentro da ENTIDADE, por exemplo
[Campo('NOME_ESTADO'),ignore], assim é possível fazer o BIND no form com campos de tabelas estrangeiras, nesse caso consigo usar a ENTIDADE CIDADE  e listar o nome do estado usando o BIND no form.