### PR TITLE
Ajustando DataSetToEntity para utilizar o Name do atributo Campo

### DIFF
--- a/SimpleRTTI.pas
+++ b/SimpleRTTI.pas
@@ -392,6 +392,8 @@ var
   prpRtti   : TRttiProperty;
   Info     : PTypeInfo;
   Value : TValue;
+  Attribute: TCustomAttribute;
+  vCampo: string;
 begin
   Result := Self;
   aDataSet.First;
@@ -405,7 +407,14 @@ begin
           typRtti := ctxRtti.GetType(Info);
           for prpRtti in typRtti.GetProperties do
           begin
-            if prpRtti.Name = Field.DisplayName then
+            vCampo  := '';
+            for Attribute in prpRtti.GetAttributes do
+            begin
+              if (Attribute is Campo) then
+                vCampo := Campo(Attribute).Name;
+            end;
+
+            if LowerCase(vCampo) = LowerCase(Field.DisplayName) then
             begin
               case prpRtti.PropertyType.TypeKind of
                 tkUnknown: Value := Field.AsString;
@@ -475,8 +484,8 @@ begin
               if (Attribute is Campo) then
                 vCampo := Campo(Attribute).Name;
             end;
-          
-            if vCampo = Field.DisplayName then
+
+            if LowerCase(vCampo) = LowerCase(Field.DisplayName) then
             begin
               case prpRtti.PropertyType.TypeKind of
                 tkUnknown: Value := Field.AsString;


### PR DESCRIPTION
Ajustando DataSetToEntity para utilizar o Name do atributo Campo da property para comparar com o nome do field da tabela na hora de efetuar o bind. Implementei o mesmo código já utilizado no DataSetToEntityList.