### PR TITLE
Atribuir o Items.Objects ao valor do Combobox

### DIFF
--- a/SimpleRTTI.pas
+++ b/SimpleRTTI.pas
@@ -165,7 +165,7 @@ begin
     (aComponent as TEdit).Text := aValue;
 
   if aComponent is TComboBox then
-    (aComponent as TComboBox).ItemIndex := (aComponent as TComboBox).Items.IndexOf(aValue);
+    (aComponent as TComboBox).ItemIndex := (aComponent as TComboBox).Items.IndexOfObject(TObject(Integer(aValue)));
 
   {$IFDEF VCL}
   if aComponent is TRadioGroup then
@@ -255,7 +255,7 @@ begin
     Result := TValue.FromVariant((aComponent as TEdit).Text);
 
   if aComponent is TComboBox then
-    Result := TValue.FromVariant((aComponent as TComboBox).Items[(aComponent as TComboBox).ItemIndex]);
+    Result := Integer((aComponent as TComboBox).Items.Objects[(aComponent as TComboBox).ItemIndex]);
 
   {$IFDEF VCL}
   if aComponent is TRadioGroup then


### PR DESCRIPTION
O combobox deve retornar e gravar o valor do Objects ao invés do ItemIndex. 